### PR TITLE
feat: Add Dockerfile.ppc64le (#424)

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,70 @@
+ARG UBI_MINIMAL_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal
+ARG UBI_BASE_IMAGE_TAG=latest
+ARG PROTOC_VERSION=29.3
+ARG CONFIG_FILE=config/config.yaml
+
+## Rust builder ################################################################
+# Specific debian version so that compatible glibc version is used
+FROM rust:1.87.0 AS rust-builder
+ARG PROTOC_VERSION
+
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+# Install protoc, no longer included in prost crate
+RUN cd /tmp && \
+    apt update && \
+    apt install -y cmake libclang-dev && \
+    curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-ppcle_64.zip; \
+    unzip protoc-*.zip -d /usr/local && \
+    rm protoc-*.zip
+
+ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib/
+
+WORKDIR /app
+
+COPY rust-toolchain.toml rust-toolchain.toml
+
+RUN rustup component add rustfmt
+
+## Orchestrator builder #########################################################
+FROM rust-builder AS fms-guardrails-orchestr8-builder
+ARG CONFIG_FILE=config/config.yaml
+
+COPY build.rs *.toml LICENSE /app/
+COPY ${CONFIG_FILE} /app/config/config.yaml
+COPY protos/ /app/protos/
+COPY src/ /app/src/
+COPY tests/ /app/tests/
+
+WORKDIR /app
+
+# TODO: Make releases via cargo-release
+RUN cargo build --release
+
+# Copy test resources required for executing unit tests
+COPY tests/resources /app/tests/resources
+RUN cargo test
+
+## Release Image ################################################################
+
+FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS fms-guardrails-orchestr8-release
+ARG CONFIG_FILE=config/config.yaml
+
+COPY --from=fms-guardrails-orchestr8-builder /app/target/release/fms-guardrails-orchestr8 /app/bin/
+COPY ${CONFIG_FILE} /app/config/config.yaml
+
+RUN microdnf install -y --disableplugin=subscription-manager shadow-utils compat-openssl11 && \
+    microdnf clean all --disableplugin=subscription-manager
+
+RUN groupadd --system orchestr8 --gid 1001 && \
+    adduser --system --uid 1001 --gid 0 --groups orchestr8 \
+    --create-home --home-dir /app --shell /sbin/nologin \
+    --comment "FMS Orchestrator User" orchestr8
+
+USER orchestr8
+
+HEALTHCHECK NONE
+
+ENV ORCHESTRATOR_CONFIG=/app/config/config.yaml
+
+CMD ["/app/bin/fms-guardrails-orchestr8"]


### PR DESCRIPTION
(cherry picked from commit 919f1c57496dd0e27bea4ce27fffde4e9dad75e0)

## Summary by Sourcery

Add a new Dockerfile.ppc64le to enable Docker image builds on the ppc64le architecture

New Features:
- Add Dockerfile.ppc64le to support building Docker images on the ppc64le architecture

Build:
- Introduce a dedicated Dockerfile for ppc64le-based builds